### PR TITLE
Added LiveServer to docs env

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 AJD = "554d0510-86f8-456b-923c-97159df4572d"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"


### PR DESCRIPTION
Info: Locally was Manifest.toml present in the docs dir. AJD package was not able to be located without the Manifest.toml (Would point to a local package via the path). Solution was to execute `(docs) pkg> add ../AJD.jl\\`.