### PR TITLE
NG_Jade_Diag new branch

### DIFF
--- a/src/AJD.jl
+++ b/src/AJD.jl
@@ -17,7 +17,7 @@ function Jacobi_Rotation(G::Matrix)
     Eigenvalues, Eigenvector = eigen(G) #sorted by highest value last
 
     max_eigenvector = Eigenvector[:,end] #get the eigenvector of the corresponding highest eigenvalue
-    max_eigenvector = sign(max_eigenvector[1])*max_eigenvector #why is that? i don't know why i need to do that but the code says so?
+    #max_eigenvector = sign(max_eigenvector[1])*max_eigenvector #why is that? i don't know why i need to do that but the code says so?
     
     x = max_eigenvector[1]
     y = max_eigenvector[2]
@@ -27,7 +27,7 @@ function Jacobi_Rotation(G::Matrix)
 
     c = sqrt((x+r)/2*r)
 
-    s = (y - z*im)/(sqrt(2*r(x+r)))
+    s = (y - z*im)/(sqrt(2*r*(x+r)))
     R = [c conj(s); -s conj(c)]
     return R
 

--- a/src/jdiag_gabrieldernbach.jl
+++ b/src/jdiag_gabrieldernbach.jl
@@ -5,8 +5,7 @@ JDiag algorithm based on the implementation by Gabrieldernbach in Python.
 
 Source: https://github.com/gabrieldernbach/approximate_joint_diagonalization/blob/master/jade/jade_cpu.py
 """
-
-function jdiag_gabrieldernbach(A::Vector{Matrix{Float64}}; threshold = 10e-18, max_iter = 1000)
+function jdiag_gabrieldernbach(A::Vector{Matrix{Float64}}; threshold = eps(), max_iter = 1000)
     #A concatenate in third dimension by  A =[[1 2; 1 2];;;[2 3; 4 5]]
     #only works for Real Matrices of A but not complex
     #A = Float64.(A) #if the Array isn't already of Float64
@@ -19,12 +18,12 @@ function jdiag_gabrieldernbach(A::Vector{Matrix{Float64}}; threshold = 10e-18, m
     iteration_step = 0
 
     active = true #flag if threshold is reached
-    while iteration_step >= max_iter || active == true
+    while iteration_step <= max_iter && active == true
    
         active = false
 
         for row = 1:rows
-            for column = 2:columns
+            for column = row+1:columns #row_index != column_index
                 h_diag = A[row,row,:] - A[column,column,:] #first entry of h
                 h_non_diag = A[row,column,:] + A[column,row,:] #second entry of h
                 
@@ -54,6 +53,70 @@ function jdiag_gabrieldernbach(A::Vector{Matrix{Float64}}; threshold = 10e-18, m
     
     return  A,V
 
+end
+function off_diag_normation(A::Array)
+    row, column,k = size(A)
+    non_diag_elements_vector = [A[index_row, index_column,index_k] for index_row = 1:row, index_column = 1:column, index_k = 1:k if index_row != index_column]
+    normation = sum(abs.(non_diag_elements_vector).^2)
+
+    return normation
+end
+
+function jdiag_gabrieldernbach(A::Vector{Matrix{ComplexF64}}; threshold = eps(), max_iter = 1000)
+
+    A = cat(A...,dims = 3)
+    rows, columns, k = size(A)
+    #initialize the apporximate joint eigenvecotrs as described in Cardoso
+    V = Matrix((1.0)*I(rows)+im*zeros(rows,rows)) #needs to be added otherwise we cannot manipulate the non diag. elements of V
+
+    objective_function = off_diag_normation(A)
+   
+    iteration_step = 0
+    active = true
+    
+
+
+    while iteration_step <= max_iter && active == true
+        active = false
+        for row = 1:rows
+            for column = row+1:columns
+                #TODO: throws a NaN for the last values in the Matrix A, unclear why it does that, works well with normal indexing!
+                h_diag = A[row,row,:] - A[column, column,:]
+                h_non_diag = A[row,column,:] + A[column,row,:]
+                h_imag = A[column,row,:] - A[row,column,:]
+            
+                h = [h_diag h_non_diag h_imag]
+                
+                #TODO: Make h_diag elements the transposed vecotrs!
+                G = Matrix{Number}[]
+                for k_index = 1:k
+                    if isempty(G) == false
+                        G = G + real(adjoint(transpose(h[k,:]))*transpose(h[k,:]))
+                    else
+                        G = real(adjoint(transpose(h[k,:]))*transpose(h[k,:]))
+                    end
+                end
+                #@info typeof(G)
+                R = Jacobi_Rotation(G)
+                
+                for k_index = 1:k
+                    A[[row,column],[row,column],k_index] = R*A[[row,column],[row,column],k_index]*adjoint(R) #might not be correct, maybe use the matrix and multiply like in the python code
+                end
+            end
+        
+        end
+    
+        objective_function_new = off_diag_normation(A)
+        diff = objective_function_new - objective_function
+
+        if abs(diff) <= threshold
+            active = true
+        end
+        objective_function = objective_function_new
+        iteration_step += 1
+    end
+    return A
+    #TODO: Return Eigenvectors V as well
 end
 
 function Is_Commuting(A::AbstractMatrix, B::AbstractMatrix)

--- a/test/test_jdiag_gabrieldernbach.jl
+++ b/test/test_jdiag_gabrieldernbach.jl
@@ -1,10 +1,9 @@
 using PyCall
-using AJD
+#using AJD
 using LinearAlgebra
 
 # Python implementation of the JDiag algorithm.
 # Source: https://github.com/gabrieldernbach/approximate_joint_diagonalization/blob/master/jade/jade_cpu.py
-
 py"""
 import numpy as np
 
@@ -57,9 +56,10 @@ def jade(A, threshold=10e-16):
 """
 
 @testset "JDiag Gabrieldernbach vs Python with I" begin
-        testinput = 1.0 * [Matrix(I, 6, 6) , Matrix(I, 6, 6)]
-        #testinput = 1.0 * [[1 2; 1 5];;;[10 3; 4 5]]
-        #A, V = py"jade"(testinput)
+       
+        testinput = (1.0)* [Matrix(I, 6, 6) , Matrix(I, 6, 6)]
+       
+        A, V = py"jade"(testinput)
         #@test A[1, :, :] == I(6)
         #testinput_python_script = []
         Python_Output = py"jade"(testinput)[1]
@@ -71,9 +71,13 @@ def jade(A, threshold=10e-16):
                 Converted_Output = cat(Converted_Output, Python_Output[i,:,:],dims = 3)
             end
         end
-        @info Converted_Output
+        # @info Converted_Output
         @test diagonalize(testinput, "jdiag")[1] == Converted_Output
         @info "Julia code from python Repo", diagonalize(testinput, "jdiag")[1]
-        @info "Python Code", py"jade"(testinput)[1]
+        # @info "Python Code", py"jade"(testinput)[1]
         #@test isapprox(diagonalize(testinput, "jdiag")[1], py"jade"(testinput)[1])
+end
+@testset "Jdiag Complex Matrices" begin
+    testinput = [[ 1.0 0.0 1.0*im; 0.0 2.0 0.0; 1.0*im 0.0 1.0],[ 1.0 0.0 1.0*im; 0.0 2.0 0.0; 1.0*im 0.0 1.0]]
+    @info "Julia code from python Repo", diagonalize(testinput, "jdiag")
 end


### PR DESCRIPTION
New branch since old NG_Jade branch was not kept up to date and was too far behind the master branch.
Includes the Joint Diagonalization for complex matrices some testing for them and some bugfixes for Jacobian_Rotation function and a (now deprecated in AJD.jl file) function for the calculation of the norm of offdiagonal elements. 
Based on the calculations done in Cardoso