### PR TITLE
Use same norm function for edourdpineau as other

### DIFF
--- a/src/jdiag_algorithms/FFDiag.jl
+++ b/src/jdiag_algorithms/FFDiag.jl
@@ -24,7 +24,7 @@ function FFD!(A::Vector{M}; threshold = eps(), max_iter = 1000, norm_ = "frobeni
     
     w = sort_offdiag_elements(W)
     e = sort_offdiag_elements(E)
-    objective = frobenius_offdiag_normation(A)
+    objective = frobenius_offdiag_norm(A)
     
     #while active == true && iteration_step <= max_iter
     while iteration_step <= max_iter
@@ -48,7 +48,7 @@ function FFD!(A::Vector{M}; threshold = eps(), max_iter = 1000, norm_ = "frobeni
             A[:,:,m] = (I+W)*A[:,:,m]*(I+W)'
         end
         
-        objective_new = frobenius_offdiag_normation(A)
+        objective_new = frobenius_offdiag_norm(A)
         diff = objective - objective_new
         objective = objective_new 
         

--- a/src/jdiag_algorithms/jdiag_edourdpineau.jl
+++ b/src/jdiag_algorithms/jdiag_edourdpineau.jl
@@ -1,13 +1,4 @@
-using Base:OneTo
-
-function off_diag_norm(Xm::AbstractArray{T,3})::Real where {T<:Union{Real,Complex}}
-    sum = zero(real(T))
-    for i in axes(Xm, 1), j in axes(Xm, 2), k in axes(Xm, 3)
-        i == j && continue
-        sum += abs2(Xm[i, j, k])
-    end
-    return sum
-end
+using Base: OneTo
 
 function rotation(aii::Array{T}, ajj::Array{T}, aij::Array{T}, aji::Array{T})::Matrix{T} where {T<:Complex}
     h = hcat(aii .- ajj, aij .+ aji, (aji .- aij) .* 1im)
@@ -40,7 +31,7 @@ function rotation_symmetric(aii::Array{T}, ajj::Array{T}, aij::Array{T})::Matrix
 end
 
 """
-    jdiag_edourdpineau(X::Vector{M}; iter=100, eps=1e-3) 
+    jdiag_edourdpineau(X::Vector{M}; iter=100, eps=1e-3)
         where {T<:Union{Real,Complex},M<:AbstractMatrix{T}}
 
 Diagonalize a set of matrices using the Jacobi method ("Jacobi Angles for Simultaneous Diagonalization").

--- a/src/jdiag_algorithms/jdiag_edourdpineau.jl
+++ b/src/jdiag_algorithms/jdiag_edourdpineau.jl
@@ -38,7 +38,7 @@ Diagonalize a set of matrices using the Jacobi method ("Jacobi Angles for Simult
 Code adapted from [Edouardpineaus Python implementation](https://github.com/edouardpineau/Time-Series-ICA-with-SOBI-Jacobi)
 """
 function jdiag_edourdpineau(X::Vector{M}; iter=100, eps=1e-3) where {T<:Number,M<:AbstractMatrix{T}}
-    
+
     Xm = cat(X..., dims=3) .+ 0.0im # change to Xm = complex.(cat(X..., dims = 3))? -NG
     m = length(X)
     n = size(X[1], 1)
@@ -51,7 +51,7 @@ function jdiag_edourdpineau(X::Vector{M}; iter=100, eps=1e-3) where {T<:Number,M
         V = Matrix{T}(I, n, n)
     end
 
-    diag_err = off_diag_norm(Xm)
+    diag_err = frobenius_offdiag_norm(Xm)
     err_array = [diag_err]
     diff = Inf
     current_iter = 0
@@ -73,7 +73,7 @@ function jdiag_edourdpineau(X::Vector{M}; iter=100, eps=1e-3) where {T<:Number,M
             V[:, [i, j]] = V[:, [i, j]] * R'
         end
 
-        new_diag_err = off_diag_norm(Xm)
+        new_diag_err = frobenius_offdiag_norm(Xm)
         push!(err_array, new_diag_err)
         # TODO: this is relative error, should also add an absolute error
         diff = abs(new_diag_err - diag_err) / diag_err

--- a/src/jdiag_algorithms/jdiag_gabrieldernbach.jl
+++ b/src/jdiag_algorithms/jdiag_gabrieldernbach.jl
@@ -86,7 +86,7 @@ function jdiag_gabrieldernbach!(A::Vector{M}; threshold = eps(), max_iter = 1000
     #needs to be added otherwise we cannot manipulate the non diag. elements of V
     
     #objective_function to be minimized by algorithm
-    objective_function = frobenius_offdiag_normation(A)
+    objective_function = frobenius_offdiag_norm(A)
    
     #conditions for abortion initialized
     iteration_step = 0
@@ -136,7 +136,7 @@ function jdiag_gabrieldernbach!(A::Vector{M}; threshold = eps(), max_iter = 1000
         
         end
     
-        objective_function_new = frobenius_offdiag_normation(A)
+        objective_function_new = frobenius_offdiag_norm(A)
         diff = objective_function_new - objective_function
         
         if abs(diff) > threshold

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -77,7 +77,7 @@ function create_linear_filter(A::Matrix{T} where {T<:Number})
 end
 
 """
-    frobenius_off_diag_normation(A::Array{<:Number,3})
+    frobenius_off_diag_norm(A::Array{<:Number,3})
 Input
 * A: Vector of matrices
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -71,13 +71,14 @@ Input
 Takes an array namely the Array of matrices A_k and gets the offdiagonal elements and applies the frobenius norm (∑ |a_{i,j}|^{2}). 
 Used for the `jdiag_gabrieldernbach` and `FFD` algorithm.
 """
-#TODO: Might be better to put back into jdiag_gabrieldernbach since it is only used there? - NG
-function frobenius_offdiag_normation(A::Array{<:Number,3})
-    #slower method instead of using get_off_diag_elements
-    # row,column,k = size(A)
-    # non_diag_elements_vector = [A[index_row, index_column,index_k] for index_row = 1:row, index_column = 1:column, index_k = 1:k if index_row != index_column]
-    #new method -NG
-    return sum(abs.(get_offdiag_elements(A)).^2) #frobenius norm is applied
+
+function frobenius_offdiag_norm(Xm::AbstractArray{T,3})::Real where {T<:Number}
+    sum = zero(real(T))
+    for i in axes(Xm, 1), j in axes(Xm, 2), k in axes(Xm, 3)
+        i == j && continue
+        sum += abs2(Xm[i, j, k])
+    end
+    return sum
 end
 #TODO: Find out if needed
 # function frobenius_off_diag_normation(A::AbstractArray{<:Number,2})

--- a/test/test_jdiag_gabrieldernbach_utils.jl
+++ b/test/test_jdiag_gabrieldernbach_utils.jl
@@ -1,6 +1,6 @@
 using PosDefManifold
 using LinearAlgebra
-using AJD: isstrictly_diagonally_dominant, get_offdiag_elements, get_diag_elements,frobenius_offdiag_normation, sort_offdiag_elements
+using AJD: isstrictly_diagonally_dominant, get_offdiag_elements, get_diag_elements,frobenius_offdiag_norm, sort_offdiag_elements
 
 
 @testset "strictly_dominant" begin
@@ -15,9 +15,9 @@ end
 end
 @testset "frobenius_off_diag_normation" begin
     input = [[1 2 3; 4 5 6; 7 8 9];;;[0 2 4; 4 2 1; 9 0 1]]
-    @test frobenius_offdiag_normation(input) == 296
+    @test frobenius_offdiag_norm(input) == 296
     input = reshape(repeat(Matrix(1.0I,3,3), outer = (1,2)),3,3,2)
-    @test frobenius_offdiag_normation(input) == 0
+    @test frobenius_offdiag_norm(input) == 0
 end
 @testset "get_diag_elements" begin
     input = reshape(repeat(Matrix(1.0I,3,3), outer = (1,2)),3,3,2)


### PR DESCRIPTION
Uses a norm function that doesnt do any copy

Also renamed form "normation" to "norm" since the function is returning the norm, not performing normation