### PR TITLE
Docstring fix in utils.jl, jdiag_cardoso.jl, jdiag_gabrieldernbach

### DIFF
--- a/docs/src/testdata_generation.md
+++ b/docs/src/testdata_generation.md
@@ -13,7 +13,7 @@ data = AJD.get_test_data(:exact_diag; n_dim = 10, n_matrices = 10)
 filter_ = diagonalize(data)
 ```
 
-with data being a random set of normal commuting matrices with dimension `n_dim` ``\\times`` `n_dim` ``\\times`` `n_matrices`.
+with data being a random set of normal commuting matrices with dimension `n_dim` ``\times`` `n_dim` ``\times`` `n_matrices`.
 
 The first way is essentially the same as writing:
 
@@ -64,7 +64,7 @@ Source Signals are time dependent functions, but for **testing purposes only** d
 
 Be careful though with choosing functions since if the variance of the signal becomes zero for long times the correlation matrix will include NaN values!
 
-The input `mixing_matrix` can be a random matrix, the only constraint being that it has to have the same column size as signals in the source signals vector. Otherwise the calculation of the measurements/observations ``x_i = \\sum_{j=1}^m A_{ij}s_j(t)`` won't be possible. (For further information about calculation of the measurements see [Ziehe (p.6 ff.)](https://publishup.uni-potsdam.de/opus4-ubp/frontdoor/deliver/index/docId/501/file/ziehe.pdf))
+The input `mixing_matrix` can be a random matrix, the only constraint being that it has to have the same column size as signals in the source signals vector. Otherwise the calculation of the measurements/observations ``x_i = \sum_{j=1}^m A_{ij}s_j(t)`` won't be possible. (For further information about calculation of the measurements see [Ziehe (p.6 ff.)](https://publishup.uni-potsdam.de/opus4-ubp/frontdoor/deliver/index/docId/501/file/ziehe.pdf))
 ```julia 
 # mixing matrix is the same as in https://doi.org/10.21595/jve.2021.21961 p.1709
 mixing_matrix =  [0.32 -0.43; -1.31 0.34]

--- a/src/jdiag_algorithms/jdiag_cardoso.jl
+++ b/src/jdiag_algorithms/jdiag_cardoso.jl
@@ -4,12 +4,12 @@
 Only works for matrix with real valued entries. Based on [Matlab Code by Cardoso](https://www2.iap.fr/users/cardoso/jointdiag.html).
 
 Input:
-* A is a mxnm matrix,(A1,...,An), each with dimension mxm
+* A is a ``m×m×n`` matrix,(``A_1,...,A_n``), each with dimension ``m×m``
 * thresh is a threshold for approximation stop, normally = 10e-8.
 
 Output:
-* V : is a  mxm matrix, which accumulates givens rotations G in each iteration.
-* A : is a mxnm matrix, which contains [VA1V',...,VAnV']
+* V : is a  ``m × m`` matrix, which accumulates givens rotations G in each iteration.
+* A : is a `` m × m × n`` matrix, which contains [``VA_1V'``,...,``VA_nV'``]
 * iter: accumulates the iteration numbers
 """
 function jdiag_cardoso(

--- a/src/jdiag_algorithms/jdiag_gabrieldernbach.jl
+++ b/src/jdiag_algorithms/jdiag_gabrieldernbach.jl
@@ -1,11 +1,13 @@
 """
-    (1) jdiag_gabrieldernbach(A::Vector{Matrix{Float64}}; threshold = eps(), max_iter = 1000)
+    (1) jdiag_gabrieldernbach(A::Vector{Matrix{Float64}}; 
+        threshold = eps(), max_iter = 1000)
 
 JDiag algorithm based on the implementation by Gabrieldernbach in Python.
 
 Source: [Algorithm](https://github.com/gabrieldernbach/approximate_joint_diagonalization/blob/master/jade/jade_cpu.py)
 
-    (2) jdiag_gabrieldernbach(A::Vector{Matrix{ComplexF64}}; threshold = eps(), max_iter = 1000)
+    (2) jdiag_gabrieldernbach(A::Vector{Matrix{ComplexF64}}; 
+        threshold = eps(), max_iter = 1000)
 
 JDiag algorithm for complex matrices based on the implementation by Gabrieldernbach in Python, the Cardoso Paper and the code 
 of [Algorithm](https://github.com/edouardpineau/Time-Series-ICA-with-SOBI-Jacobi)


### PR DESCRIPTION
- changed docstrings `generate_testdata` in `utils.jl`, `jdiag_cardoso.jl` docstring, `jdiag_gabrieldernbach` docstring to be more in line with the other functions
- changed docstring for `generate_testdata` and added example for `signal_sources` and `mixing_matrix` to the continous case
- changed md file for testdata generation (@muehlefeldt would be good if you'd look over it and if that is what you wanted)