### PR TITLE
Should fix the problem with wav files not being part of the temp env

### DIFF
--- a/src/jdiag_algorithms/jdiag_cardoso.jl
+++ b/src/jdiag_algorithms/jdiag_cardoso.jl
@@ -4,7 +4,7 @@
 Only works for matrix with real valued entries. Based on [Matlab Code by Cardoso](https://www2.iap.fr/users/cardoso/jointdiag.html).
 
 Input:
-* A is a ``m×m×n`` matrix,(``A_1,...,A_n``), each with dimension ``m×m``
+* A is a ``m × m × n`` matrix,(``A_1,...,A_n``), each with dimension ``m × m``
 * thresh is a threshold for approximation stop, normally = 10e-8.
 
 Output:

--- a/src/utils_test_data.jl
+++ b/src/utils_test_data.jl
@@ -11,16 +11,19 @@ Usage:
 * `:approx_diag`
 * `:random_noice`
 """
-#TODO: Change n_dim and n_matrices to kwargs?
+#not pretty but if the files should be included the directory is needed to make abs. path
+directory = dirname(@__DIR__)
 function get_test_data(type::Symbol, n_dim::Int = 10, n_matrices::Int = 10)
     if type == :exact_diag
         return random_normal_commuting_matrices(n_dim, n_matrices)
     elseif type == :approx_diag 
-        data, _ = wavread("test_data/channels3_room69_mix.wav")
+        file = "/test_data/channels3_room69_mix.wav"
+        data, _ = wavread(directory * file)
         return AJD.generate_testdata(data', delay = 1000, no_of_segments = 6, 
         show_warning = false)
     elseif type == :approx_diag_large
-        data, _ = wavread("test_data/channels3_room69_mix.wav")
+        file = "/test_data/channels3_room69_mix.wav"
+        data, _ = wavread(directory * file)
         return AJD.generate_testdata(data', delay = 1000, no_of_segments = n_matrices+1,
         show_warning = false)
     elseif type ==:random_noice


### PR DESCRIPTION
- added `directory = dirname(@__DIR__)` to `test_data_utils.jl` to build abs path for wav files.