### PR TITLE
removed isstrictly_diagonally_dominant

### DIFF
--- a/src/FFDiag.jl
+++ b/src/FFDiag.jl
@@ -38,18 +38,23 @@ function ffd(
     if typeof(A) <: AbstractArray{<:AbstractArray{<:Int}}
         A = float.(A)
     end
+    #convert to 3 dimensional matrix and concatenate in the third dimension
+    #will also reset dimensions of matrix if OffsetArray
+    A = cat(A..., dims = 3)::AbstractArray{<:Real}
+
     #choose norm according to reference in docstring
     if norm_ == :frobenius
-        norm_function = X -> norm(X,2) #frobenius norm, it says it is frobenius norm but that doesn't make sense!
+        norm_function = X -> norm(X,2) 
+        #frobenius norm according to LinearAlgebra docs
     elseif norm_ == :inf
-        norm_function = X -> opnorm(X,Inf) #infinity norm
+        norm_function = X -> opnorm(X,Inf) 
+        #infinity norm
+        #according to LinearAlgebra docs
     end
 
     # Initial setup of the progressbar.
     progress_bar = ProgressThresh(threshold; desc="Minimizing:")
-    #convert to 3 dimensional matrix and concatenate in the third dimension
-    #will also reset dimensions of matrix if OffsetArray
-    A = cat(A..., dims = 3)::AbstractArray{<:Real}
+    
 
     rows,columns,k = size(A)
     #initialization
@@ -74,7 +79,8 @@ function ffd(
         iteration_step += 1
         E = get_offdiag_elements(A)
         D = get_diag_elements(A)
-        #can be done since cat will reset indices which will work with OffsetArrays and
+        #can be done since cat will 
+        #reset indices which will work with OffsetArrays and
         #linear indexing
         for i = 1:rows-1, j = i+1:rows
             z_ij = get_z_fdiag(D,i,j)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -114,21 +114,6 @@ function is_commuting(A::AbstractMatrix, B::AbstractMatrix)
     return isapprox(A*B, B*A)
 end
 
-"""
-    isstrictly_diagonally_dominant(A::AbstractMatrix)
-* A: AbstractMatrix
-
-Used for the FFDiag Algorithm to define whether the Matrix A is strictly diagonally dominant and therefore has an Inverse or not.
-A matrix is strictly dominant if: ``|a_{ii}| > \\sum |a_{ij}|, i ≠ j``
-"""
-function isstrictly_diagonally_dominant(A::AbstractMatrix)
-    for i in eachindex(IndexCartesian(),A[:, 1])
-        if abs(sum(A[i,:])) - abs(A[i,i]) > abs(A[i,i]) ? true : false
-            return false
-        end
-    end
-    return true
-end
 
 """
     get_z_fdiag(D::AbstractArray{<:Number}, i::Int, j::Int)

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -105,12 +105,6 @@ end
 
 end
 
-
-@testset "strictly_dominant" begin
-    A = 1.0*Matrix(I,3,3)
-    @test AJD.isstrictly_diagonally_dominant(A) == true
-end
-
 @testset "get_off_diag_elements" begin
     input = [[1 2 3; 4 5 6; 7 8 9];;;[0 2 4; 4 2 1; 9 0 1]]
     @test AJD.get_offdiag_elements(input) == [[0 2 3; 4 0 6; 7 8 0];;; [0 2 4; 4 0 1; 9 0 0]]


### PR DESCRIPTION
- removed strictly diagonally_dominant function since it isn't actually needed
- was a requirement for the determination of the norm for update matrix not for input matrix
- "it clearly suffices to enforce invertibility of I+W(n). The latter can be carried out using the following well known results of matrix analysis...[p780]"